### PR TITLE
DisplayArea::add_text

### DIFF
--- a/src/display/display_area.rs
+++ b/src/display/display_area.rs
@@ -133,6 +133,16 @@ impl DisplayArea {
                 .nuts_check();
         }
     }
+
+    /// Takes a floating text and attaches it to the display area.
+    ///
+    /// Previously specified coordinates will become relative to the display
+    /// area. Only call this once per text, or the coordinate transformation
+    /// will be repeated.
+    pub fn add_text(&self, text: &mut crate::FloatingText) {
+        text.translate(self.region.pos).unwrap();
+    }
+
     /// The size of the selected area, in game coordinates
     pub fn size(&self) -> Vector {
         self.region.size()


### PR DESCRIPTION
This method makes it easier to position a text relative to a frame, rather than relative than relative to the entire screen.