### PR TITLE
fix: screen fitting true to game coordinates

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -214,8 +214,8 @@ impl Display {
         let (w, h) = scale_to_ratio(
             w - self.browser_region.x() as f64 - margin,
             h - self.browser_region.y() as f64 - margin,
-            self.browser_region.width() as f64,
-            self.browser_region.height() as f64,
+            self.game_coordinates.x as f64,
+            self.game_coordinates.y as f64,
         );
 
         self.canvas.set_size((w as f32, h as f32));


### PR DESCRIPTION
The old (buggy) behavior fitted to scale of the visible browser area. This leads to distorted display.
As a side-effect, this also makes the click events fire at the wrong coordinate because the displayed images are not where they should.